### PR TITLE
Add new option 'headers'

### DIFF
--- a/demo/headers.html
+++ b/demo/headers.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Hideseek headers</title>
+    <style >
+      <!--
+        ul { list-style-type: none;}
+        li { margin-left: 20px; }
+        .origin { font-weight: bold; margin-left: 8px; }
+
+      -->
+    </style>
+  </head>
+  <body>
+    <h1>Ancient Gods</h1>
+    <input type="text" id="hs-headers" data-list="#list" placeholder="start typing here...">
+    <ul id="list">
+      <li class="origin">Greek</li>
+      <li>Zeus</li>
+      <li>Poseidon</li>
+      <li>Hades</li>
+      <li class="origin">Roman</li>
+      <li>Mars</li>
+      <li>Jupiter</li>
+      <li>Minerva</li>
+      <li class="origin">Norse</li>
+      <li>Odin</li>
+      <li>Thor</li>
+      <li>Loki</li>
+    </ul>
+  </body>
+</html>
+
+<script src="javascripts/vendor/jquery-1.9.1.min.js"></script>
+<script src="../jquery.hideseek.js"></script>
+<script type="text/javascript">
+  $(document).ready(function(){
+
+    $("#hs-headers").hideseek({
+      highlight: true,
+      headers: ".origin",
+      nodata: "Pas de résultats"
+    });
+  });
+</script>

--- a/jquery.hideseek.js
+++ b/jquery.hideseek.js
@@ -44,7 +44,8 @@
       attribute:  'text',
       highlight:  false,
       ignore:     '',
-      navigation: false
+      navigation: false,
+      headers: ''
     };
 
     var options = $.extend(defaults, options);
@@ -59,6 +60,11 @@
       options.attribute = $this.data('attribute') || options.attribute;
       options.highlight = $this.data('highlight') || options.highlight;
       options.ignore    = $this.data('ignore') || options.ignore;
+      options.headers   = $this.data('headers') || options.headers;
+
+      // adds headers to excluded items
+      if (options.headers)
+        options.ignore += options.ignore ? ', ' + options.headers : options.headers;
 
       var $list = $(options.list);
 
@@ -109,6 +115,18 @@
 
             }
 
+          }
+
+          // hide headers with no results
+          if (options.headers){
+            $(options.headers, $list).each(function(){
+              if (!$(this).nextUntil(options.headers).filter(':not([style*="display: none"])').length){
+                $(this).hide();
+              }
+              else {
+                $(this).show();
+              }
+            });
           }
 
           $this.trigger('_after');

--- a/jquery.hideseek.js
+++ b/jquery.hideseek.js
@@ -120,7 +120,7 @@
           // hide headers with no results
           if (options.headers){
             $(options.headers, $list).each(function(){
-              if (!$(this).nextUntil(options.headers).filter(':not([style*="display: none"])').length){
+              if (!$(this).nextUntil(options.headers).not('[style*="display: none"],' + options.ignore).length){
                 $(this).hide();
               }
               else {


### PR DESCRIPTION
We use HideSeek with a 2 level list: items belong to categories, which have a title.
This option allows to specify headers items, which are ignored from the search, and are hidden when all their "children" (siblings in DOM) are excluded from the results.

See demo/headers.html for example.