### PR TITLE
Fix problem with removeAccents: true

### DIFF
--- a/jquery.hideseek.js
+++ b/jquery.hideseek.js
@@ -71,7 +71,7 @@
 
         if (e.keyCode != 38 && e.keyCode != 40 && e.keyCode != 13) {
 
-          var q = $this.val().toLowerCase();
+          var q = $this.val().toLowerCase().removeAccents($this.opts.ignore_accents);
 
           $list.children($this.opts.ignore.trim() ? ":not(" + $this.opts.ignore + ")" : '').removeClass('selected').each(function() {
 


### PR DESCRIPTION
When removeAccents is true, all accents in the searchable elements are removed. But if you type an accent like "ä" in your search input this value is not modified and the search results are not correct.

Therefore if removeAccents is activated all accents should also be removed from the searchvalue.

Hope this is correct and I didn't overlook something.
